### PR TITLE
send_mess() uses 'const char *'

### DIFF
--- a/faulhaberApp/src/drvMCDC2805.cc
+++ b/faulhaberApp/src/drvMCDC2805.cc
@@ -73,14 +73,14 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* --- Local data. --- */
 int MCDC2805_num_cards = 0;
-static char *MCDC2805_axis[] = {"0", "1", "2", "3", "4", "5", "6", "7"};
+static const char *MCDC2805_axis[] = {"0", "1", "2", "3", "4", "5", "6", "7"};
 
 /* Local data required for every driver; see "motordrvComCode.h" */
 #include    "motordrvComCode.h"
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -375,7 +375,7 @@ exit:
 /* send a message to the MCDC2805 board            */
 /* send_mess()                               */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char local_buff[MAX_MSG_SIZE];
     struct MCDC2805controller *cntrl;


### PR DESCRIPTION
The 3rd parameter in send_mess(), "name" can and should
be a 'const char *' instead of just 'char *'.
Modern compilers complain here, so that the signature now
gets the const.

This is a minimal part of a series from Dirk Zimoch,
more warnings can be removed here and there.